### PR TITLE
Add Rectangle window manager to Brewfile

### DIFF
--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -73,6 +73,7 @@ cask "r"
 cask "rstudio"
 
 # Window Management
+cask "rectangle"
 cask "spectacle"
 
 # Fonts


### PR DESCRIPTION
## Summary
Added Rectangle, a modern window management application, to the Homebrew dependencies.

## Changes
- Added `cask "rectangle"` to the Window Management section of the Brewfile

## Details
Rectangle is being added alongside the existing Spectacle window manager. This provides an additional option for window management on macOS systems managed by this Brewfile configuration.

https://claude.ai/code/session_011XNxwBjxGSE5z4xumrePg3